### PR TITLE
PCR_Port_C update address

### DIFF
--- a/Projects/c5_embedded101/c5_embedded101/include/embedded101.h
+++ b/Projects/c5_embedded101/c5_embedded101/include/embedded101.h
@@ -79,7 +79,9 @@ typedef struct {
 #define PCC_ENABLE_PORT_MASK		(1u << 30)
 
 /*********** PCR - Port Control Register *******************/
-#define PCR_PORT_D		((uint32_t *)(0x4004C000))	/* PCC PORT C address */
+#define PCR_PORT_D		((uint32_t *)(0x4004C000))	/* PCC PORT D address */
+#define PCR_PORT_C		((uint32_t *)(0x4004B000))	/* PCC PORT C address */
+
 
 #define PCR_GPIO_MODE_MASK		(1 << 8)
 


### PR DESCRIPTION
I've added PCR_Port_C address wich was further used to enable port function for PCR MUX GPIO.